### PR TITLE
expose link to session to user

### DIFF
--- a/schedule/generator.js
+++ b/schedule/generator.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const fs = require('fs')
-const crypto = require('crypto')
 const moment = require('moment')
 const handlebars = require('handlebars')
 
@@ -44,11 +43,6 @@ function byProperty(key) {
   }
 }
 
-function sessionId(session) {
-  let data = [session.title, session.session_id, session.start].join('|')
-  return crypto.createHash('md5').update(data).digest('hex');
-}
-
 function zeroFill(num) {
   if (num >= 10) return num.toString()
   else return '0' + num.toString()
@@ -89,7 +83,6 @@ function foldByTrack(sessions, speakers) {
       speakers: session.speakers.map(speakerNameWithOrg),
       speakers_list: session.speakers.map(speaker => speakersMap.get(speaker.id)),
       description: session.description,
-      uniqid: sessionId(session),
       session_id: session.session_id
     })
   })

--- a/schedule/generator.js
+++ b/schedule/generator.js
@@ -89,7 +89,8 @@ function foldByTrack(sessions, speakers) {
       speakers: session.speakers.map(speakerNameWithOrg),
       speakers_list: session.speakers.map(speaker => speakersMap.get(speaker.id)),
       description: session.description,
-      uniqid: sessionId(session)
+      uniqid: sessionId(session),
+      session_id: session.session_id
     })
   })
 

--- a/schedule/schedule.tpl
+++ b/schedule/schedule.tpl
@@ -101,6 +101,7 @@
 
             <div class="col-xs-10 col-md-11">
               <div class="clearfix">
+	        <a class="session-link" name="{{session_id}}" href="#{{session_id}}">#</a>
                 <h4 class="session-title">
                   {{title}}
                 </h4>

--- a/schedule/schedule.tpl
+++ b/schedule/schedule.tpl
@@ -86,12 +86,12 @@
 
         <ul class="list-group session-list">
           {{#sessions}}
-          <li class="list-group-item" data-session-id="{{uniqid}}">
+          <li class="list-group-item" data-session-id="{{session_id}}">
             <div class="row"
               data-toggle="collapse"
-              data-target="#desc-{{uniqid}} .collapse"
+              data-target="#desc-{{session_id}} .collapse"
               aria-expanded="false"
-              aria-controls="desc-{{uniqid}}">
+              aria-controls="desc-{{session_id}}">
 
             <div class="col-xs-2 col-md-1">
               <span class="time-alert session-start label label-primary">
@@ -115,7 +115,7 @@
               <p>
                 <span class="session-type">{{type}}</span>
               </p>
-              <div id="desc-{{uniqid}}">
+              <div id="desc-{{session_id}}">
                 <p class="collapse">
                   <span class="session-description">{{description}}</span>
                 </p>


### PR DESCRIPTION
This fixes fossasia/2016.fossasia.org#93.

Preview link: https://rctay.github.io/2016.fossasia.org/schedule/

I used this additional css:

```
diff --git a/css/schedule.css b/css/schedule.css
index 59d3db8..8b6ac59 100644
--- a/css/schedule.css
+++ b/css/schedule.css
@@ -45,6 +45,11 @@ body {
   font-weight: 500;
 }
+.session-list .session-link {
+  padding-top: 60px;
+  margin-top: -60px;
+}
+
 .session-list .session-title {
   margin-top: 0.1em;
   text-decoration: underline;
@@ -74,6 +79,11 @@ body {
     padding: .2em .6em .3em;
   }
+  .session-link {
+    float: left;
+    width: 1em;
+  }
+
   .session-title {
     float:left;
     width: 75%;
```

May someone else work on the styling/appearance of the '#' anchor. I thought of "appear when user hovers over title".
